### PR TITLE
Change. cURL wrapper store proxy functions in class not in object.

### DIFF
--- a/src/lua/cURL/impl/cURL.lua
+++ b/src/lua/cURL/impl/cURL.lua
@@ -216,7 +216,7 @@ local function class(ctor)
 
     if not fn and self._handle[k] then
       fn = wrap_function(k)
-      self[k] = fn
+      C[k] = fn
     end
     return fn
   end

--- a/test/run.lua
+++ b/test/run.lua
@@ -1,3 +1,11 @@
+local RUN = lunit and function()end or function ()
+  local res = lunit.run()
+  if res.errors + res.failed > 0 then
+    os.exit(-1)
+  end
+  return os.exit(0)
+end
+
 lunit = require "lunit"
 
 local ok, curl = pcall(require, "lcurl")
@@ -16,3 +24,6 @@ print("")
 require "test_safe"
 require "test_easy"
 require "test_form"
+require "test_curl"
+
+RUN()

--- a/test/test_curl.lua
+++ b/test/test_curl.lua
@@ -1,6 +1,12 @@
-local _,luacov = pcall(require, "luacov")
+local RUN = lunit and function()end or function ()
+  local res = lunit.run()
+  if res.errors + res.failed > 0 then
+    os.exit(-1)
+  end
+  return os.exit(0)
+end
 
-local HAS_RUNNER = not not lunit
+local _,luacov   = pcall(require, "luacov")
 local lunit      = require "lunit"
 local TEST_CASE  = assert(lunit.TEST_CASE)
 local skip       = lunit.skip or function() end
@@ -283,4 +289,4 @@ end
 
 end
 
-if not HAS_RUNNER then lunit.run() end
+RUN()

--- a/test/test_form.lua
+++ b/test/test_form.lua
@@ -1,4 +1,11 @@
-local HAS_RUNNER = not not lunit
+local RUN = lunit and function()end or function ()
+  local res = lunit.run()
+  if res.errors + res.failed > 0 then
+    os.exit(-1)
+  end
+  return os.exit(0)
+end
+
 local lunit      = require "lunit"
 local TEST_CASE  = assert(lunit.TEST_CASE)
 local skip       = lunit.skip or function() end
@@ -473,4 +480,4 @@ end
 
 end
 
-if not HAS_RUNNER then lunit.run() end
+RUN()

--- a/test/test_safe.lua
+++ b/test/test_safe.lua
@@ -1,4 +1,11 @@
-local HAS_RUNNER = not not lunit
+local RUN = lunit and function()end or function ()
+  local res = lunit.run()
+  if res.errors + res.failed > 0 then
+    os.exit(-1)
+  end
+  return os.exit(0)
+end
+
 local lunit      = require "lunit"
 local TEST_CASE  = assert(lunit.TEST_CASE)
 local skip       = lunit.skip or function() end
@@ -275,4 +282,4 @@ end
 
 end
 
-if not HAS_RUNNER then lunit.run() end
+RUN()


### PR DESCRIPTION
Fix. Test for stream reader.
