### PR TITLE
Need string.h for memset

### DIFF
--- a/src/l52util.c
+++ b/src/l52util.c
@@ -11,6 +11,7 @@
 #include "l52util.h"
 
 #include <memory.h>
+#include <string.h> /* for memset */
 #include <assert.h>
 
 #if LUA_VERSION_NUM >= 502 


### PR DESCRIPTION
gcc 4.8 for Android is warning about 
l52util.c:154:3: warning: incompatible implicit declaration of built-in function 'memset' [enabled by default]

#include <string.h> to fixes this.