### PR TITLE
Add. Support libcurl 7.52.1

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ shallow_clone: true
 
 environment:
   LR_EXTERNAL: c:\external
-  CURL_VER: 7.51.0
+  CURL_VER: 7.52.1
 
   matrix:
   - LUA: "lua 5.1"

--- a/src/lceasy.c
+++ b/src/lceasy.c
@@ -253,12 +253,22 @@ static int lcurl_opt_set_long_(lua_State *L, int opt){
   lcurl_easy_t *p = lcurl_geteasy(L);
   long val; CURLcode code;
 
-  if(lua_isboolean(L, 2)) val = lua_toboolean(L, 2);
+  if(lua_isboolean(L, 2)){
+    val = lua_toboolean(L, 2);
+    if( val
+      && (opt == CURLOPT_SSL_VERIFYHOST)
+#if LCURL_CURL_VER_GE(7,52,0)
+      && (opt == CURLOPT_PROXY_SSL_VERIFYHOST)
+#endif
+    ){
+      val = 2;
+    }
+  }
   else{
     luaL_argcheck(L, lua_type(L, 2) == LUA_TNUMBER, 2, "number or boolean expected");
     val = luaL_checklong(L, 2);
   }
-  
+
   code = curl_easy_setopt(p->curl, opt, val);
   if(code != CURLE_OK){
     return lcurl_fail_ex(L, p->err_mode, LCURL_ERROR_EASY, code);

--- a/src/lcflags.h
+++ b/src/lcflags.h
@@ -165,6 +165,9 @@ FLG_ENTRY(PROXY_SOCKS4                    ) /* added in 7.15.2 */
 FLG_ENTRY(PROXY_SOCKS5                    ) /* added in 7.10.0 */
 FLG_ENTRY(PROXY_SOCKS4A                   ) /* added in 7.18.0 */
 FLG_ENTRY(PROXY_SOCKS5_HOSTNAME           ) /* added in 7.18.0 */
+#if LCURL_CURL_VER_GE(7,52,0)
+FLG_ENTRY(PROXY_HTTPS                     )
+#endif
 
 FLG_ENTRY(PAUSE_ALL                       ) /* added in 7.18.0 */
 FLG_ENTRY(PAUSE_CONT                      ) /* added in 7.18.0 */

--- a/src/lcinfoeasy.h
+++ b/src/lcinfoeasy.h
@@ -47,6 +47,12 @@ OPT_ENTRY( rtsp_cseq_recv,          RTSP_CSEQ_RECV,          LNG, 0)
 OPT_ENTRY( http_version,            HTTP_VERSION,            STR, 0)
 #endif
 
+#if LCURL_CURL_VER_GE(7,52,0)
+OPT_ENTRY( proxy_ssl_verifyresult,  PROXY_SSL_VERIFYRESULT,  LNG, 0)
+OPT_ENTRY( protocol,                PROTOCOL,                LNG, 0)
+OPT_ENTRY( scheme,                  SCHEME,                  STR, 0)
+#endif
+
 // OPT_ENTRY( PRIVATE,                 void     ) 
 // OPT_ENTRY( CERTINFO,                struct curl_certinfo *
 // OPT_ENTRY( TLS_SESSION,             struct curl_tlssessioninfo *

--- a/src/lcopteasy.h
+++ b/src/lcopteasy.h
@@ -88,7 +88,7 @@ OPT_ENTRY( httpauth,               HTTPAUTH,                 LNG, 0,            
 #if LCURL_CURL_VER_GE(7,21,4)
 OPT_ENTRY( tlsauth_username,       TLSAUTH_USERNAME,         STR, LCURL_STORE_STRING, LCURL_DEFAULT_VALUE )
 OPT_ENTRY( tlsauth_password,       TLSAUTH_PASSWORD,         STR, LCURL_STORE_STRING, LCURL_DEFAULT_VALUE )
-OPT_ENTRY( tlsauth_type,           TLSAUTH_TYPE,             LNG, 0,                  CURL_TLSAUTH_NONE   )
+OPT_ENTRY( tlsauth_type,           TLSAUTH_TYPE,             STR, 0,                  "" )
 #endif
 OPT_ENTRY( proxyauth,              PROXYAUTH,                LNG, 0,                  CURLAUTH_BASIC )
 #if LCURL_CURL_VER_GE(7,31,0)
@@ -353,6 +353,27 @@ OPT_ENTRY( connect_to,         CONNECT_TO,         LST, 0,                  LCUR
 #endif
 #if LCURL_CURL_VER_GE(7,51,0)
 OPT_ENTRY( keep_sending_on_error, KEEP_SENDING_ON_ERROR, LNG, 0,            LCURL_DEFAULT_VALUE )
+#endif
+
+#if LCURL_CURL_VER_GE(7,52,0)
+OPT_ENTRY( proxy_cainfo,           PROXY_CAINFO,           STR, 0, LCURL_DEFAULT_VALUE)
+OPT_ENTRY( proxy_capath,           PROXY_CAPATH,           STR, 0, LCURL_DEFAULT_VALUE)
+OPT_ENTRY( proxy_ssl_verifypeer,   PROXY_SSL_VERIFYPEER,   LNG, 0, 1)
+OPT_ENTRY( proxy_ssl_verifyhost,   PROXY_SSL_VERIFYHOST,   LNG, 0, 2)
+OPT_ENTRY( proxy_sslversion,       PROXY_SSLVERSION,       LNG, 0, CURL_SSLVERSION_DEFAULT)
+OPT_ENTRY( proxy_tlsauth_username, PROXY_TLSAUTH_USERNAME, STR, 0, LCURL_DEFAULT_VALUE)
+OPT_ENTRY( proxy_tlsauth_password, PROXY_TLSAUTH_PASSWORD, STR, 0, LCURL_DEFAULT_VALUE)
+OPT_ENTRY( proxy_tlsauth_type,     PROXY_TLSAUTH_TYPE,     STR, 0, "")
+OPT_ENTRY( proxy_sslcert,          PROXY_SSLCERT,          STR, 0, LCURL_DEFAULT_VALUE)
+OPT_ENTRY( proxy_sslcerttype,      PROXY_SSLCERTTYPE,      STR, 0, "PEM")
+OPT_ENTRY( proxy_sslkey,           PROXY_SSLKEY,           STR, 0, LCURL_DEFAULT_VALUE)
+OPT_ENTRY( proxy_sslkeytype,       PROXY_SSLKEYTYPE,       STR, 0, "PEM") /* default value not defined. Use same as for `SSLKEYTYPE` */
+OPT_ENTRY( proxy_keypasswd,        PROXY_KEYPASSWD,        STR, 0, LCURL_DEFAULT_VALUE)
+OPT_ENTRY( proxy_ssl_cipher_list,  PROXY_SSL_CIPHER_LIST,  STR, 0, LCURL_DEFAULT_VALUE)
+OPT_ENTRY( proxy_crlfile,          PROXY_CRLFILE,          STR, 0, LCURL_DEFAULT_VALUE)
+OPT_ENTRY( proxy_ssl_options,      PROXY_SSL_OPTIONS,      LNG, 0, LCURL_DEFAULT_VALUE)
+OPT_ENTRY( pre_proxy,              PRE_PROXY,              STR, 0, LCURL_DEFAULT_VALUE)
+OPT_ENTRY( proxy_pinnedpublickey,  PROXY_PINNEDPUBLICKEY,  STR, 0, LCURL_DEFAULT_VALUE)
 #endif
 
 #ifdef LCURL__TCP_FASTOPEN

--- a/src/lcurl.c
+++ b/src/lcurl.c
@@ -110,6 +110,9 @@ static int lcurl_version_info(lua_State *L){
 #ifdef CURL_VERSION_HTTP2
     lua_pushliteral(L, "HTTP2");        lua_pushboolean(L, data->features & CURL_VERSION_HTTP2       ); lua_rawset(L, -3);
 #endif
+#ifdef CURL_VERSION_HTTPS_PROXY
+    lua_pushliteral(L, "HTTPS_PROXY");  lua_pushboolean(L, data->features & CURL_VERSION_HTTPS_PROXY ); lua_rawset(L, -3);
+#endif
   lua_setfield(L, -2, "features");         /* bitmask, see defines below */
 
   if(data->ssl_version){lua_pushstring(L, data->ssl_version); lua_setfield(L, -2, "ssl_version");}      /* human readable string */

--- a/src/lcutils.c
+++ b/src/lcutils.c
@@ -304,3 +304,32 @@ int lcurl_utils_apply_options(lua_State *L, int opt, int obj, int do_close,
   assert(lua_gettop(L) == top);
   return 0;
 }
+
+void lcurl_stack_dump (lua_State *L){
+  int i = 1, top = lua_gettop(L);
+
+  fprintf(stderr, " ----------------  Stack Dump ----------------\n" );
+  while( i <= top ) {
+    int t = lua_type(L, i);
+    switch (t) {
+      case LUA_TSTRING:
+        fprintf(stderr, "%d(%d):`%s'\n", i, i - top - 1, lua_tostring(L, i));
+        break;
+      case LUA_TBOOLEAN:
+        fprintf(stderr, "%d(%d): %s\n",  i, i - top - 1,lua_toboolean(L, i) ? "true" : "false");
+        break;
+      case LUA_TNUMBER:
+        fprintf(stderr, "%d(%d): %g\n",  i, i - top - 1, lua_tonumber(L, i));
+        break;
+      default:
+        lua_getglobal(L, "tostring");
+        lua_pushvalue(L, i);
+        lua_call(L, 1, 1);
+        fprintf(stderr, "%d(%d): %s(%s)\n", i, i - top - 1, lua_typename(L, t), lua_tostring(L, -1));
+        lua_pop(L, 1);
+        break;
+    }
+    i++;
+  }
+  fprintf(stderr, " ------------ Stack Dump Finished ------------\n" );
+}

--- a/src/lcutils.h
+++ b/src/lcutils.h
@@ -71,4 +71,7 @@ int lcurl_util_pcall_method(lua_State *L, const char *name, int nargs, int nresu
 int lcurl_utils_apply_options(lua_State *L, int opt, int obj, int do_close,
                               int error_mode, int error_type, int error_code
                               );
+
+void lcurl_stack_dump (lua_State *L);
+
 #endif

--- a/src/lua/cURL/impl/cURL.lua
+++ b/src/lua/cURL/impl/cURL.lua
@@ -360,6 +360,7 @@ Easy.setopt_proxytype = wrap_setopt_flags("proxytype", {
   ["SOCKS5"          ] = curl.PROXY_SOCKS5;
   ["SOCKS4A"         ] = curl.PROXY_SOCKS4A;
   ["SOCKS5_HOSTNAME" ] = curl.PROXY_SOCKS5_HOSTNAME;
+  ["HTTPS"           ] = curl.PROXY_HTTPS;
 })
 
 Easy.setopt_httpauth  = wrap_setopt_flags("httpauth", {

--- a/test/test_easy.lua
+++ b/test/test_easy.lua
@@ -668,9 +668,9 @@ end
 
 local _ENV = TEST_CASE'read_callback'        if ENABLE then
 
-local uname = upath:normolize(path.fullpath(fname))
+local uname = upath:normalize(path.fullpath(fname))
 
-local url   = "FILE://" .. uname
+local url   = "FILE:///" .. uname
 
 local c
 


### PR DESCRIPTION
Add. Support libcurl 7.52.1
Fix. `setopt{ssl_verifyhost=true}` set option to `2` not to `1`
Fix. Type and default value for `TLSAUTH_TYPE` option
Fix. File url in test