### PR TITLE
Fixing the type of the HTTP verision info to be long, not char*

### DIFF
--- a/src/lcinfoeasy.h
+++ b/src/lcinfoeasy.h
@@ -44,7 +44,7 @@ OPT_ENTRY( rtsp_cseq_recv,          RTSP_CSEQ_RECV,          LNG, 0)
 #endif
 
 #if LCURL_CURL_VER_GE(7,50,1)
-OPT_ENTRY( http_version,            HTTP_VERSION,            STR, 0)
+OPT_ENTRY( http_version,            HTTP_VERSION,            LNG, 0)
 #endif
 
 #if LCURL_CURL_VER_GE(7,52,0)


### PR DESCRIPTION
This allows to obtain the actually used HTTP version, and prevents a segfault while doing so.
The numerical value should of course be compared against the HTTP_VERSION_* lcurl constants (e.g. 2 means HTTP/1.1).