### PR TITLE
easy handle's lua_State need to initialize.

### DIFF
--- a/src/lcmulti.c
+++ b/src/lcmulti.c
@@ -149,6 +149,12 @@ static int lcurl_multi_add_handle(lua_State *L){
   CURLMcode code;
   lua_State *curL;
 
+  // easy handle's lua_State need to be initialized.
+  e->L = L;
+  if (e->post) {
+      e->post->L = L;
+  }
+  
   if(e->multi){
     return lcurl_fail_ex(L, p->err_mode, LCURL_ERROR_MULTI, 
 #if LCURL_CURL_VER_GE(7,32,1)


### PR DESCRIPTION
```
    local easy = curl.easy()
    easy:setopt_url('http://www.baidu.com')
    easy:setopt_writefunction(function(buf)
        print('recv', #buf)
    end)
    multi:add_handle(easy)
```

This code would crash, because easy handle's L is NULL, and never be set.