### PR TITLE
Allow use null value.

### DIFF
--- a/src/l52util.c
+++ b/src/l52util.c
@@ -156,3 +156,11 @@ int64_t lutil_optint64(lua_State *L, int idx, int64_t v){
 void lutil_pushnvalues(lua_State *L, int n){
   for(;n;--n) lua_pushvalue(L, -n);
 }
+
+int lutil_is_null(lua_State *L, int i){
+  return lua_islightuserdata(L, i) && 0 == lua_touserdata(L, i);
+}
+
+void lutil_push_null(lua_State *L){
+  lua_pushlightuserdata(L, (void*)0);
+}

--- a/src/l52util.h
+++ b/src/l52util.h
@@ -88,4 +88,8 @@ int64_t lutil_optint64(lua_State *L, int idx, int64_t v);
 
 void lutil_pushnvalues(lua_State *L, int n);
 
+int lutil_is_null(lua_State *L, int i);
+
+void lutil_push_null(lua_State *L);
+
 #endif

--- a/src/lcmime.c
+++ b/src/lcmime.c
@@ -135,7 +135,7 @@ int lcurl_mime_set_lua(lua_State *L, lcurl_mime_t *p, lua_State *v){
 
 #define IS_NILORSTR(L, i) (lua_type(L, i) == LUA_TSTRING) || (lua_type(L, i) == LUA_TNIL)
 #define IS_TABLE(L, i) lua_type(L, i) == LUA_TTABLE
-#define IS_FALSE(L, i) (lua_type(L, i) == LUA_TBOOLEAN) && (!lua_toboolean(L, i))
+#define IS_FALSE(L, i) ((lua_type(L, i) == LUA_TBOOLEAN) && (!lua_toboolean(L, i))) || lutil_is_null(L,i)
 #define IS_OPTSTR(L, i) (IS_FALSE(L, i)) || (IS_NILORSTR(L, i))
 
 static int lutil_isarray(lua_State *L, int i){
@@ -512,13 +512,13 @@ static int lcurl_mime_part_headers(lua_State *L){
   }
   else{
     list = lcurl_util_to_slist(L, 2);
-    luaL_argcheck(L, list, 2, "array or nil expected");
+    luaL_argcheck(L, list || IS_TABLE(L, 2), 2, "array or null expected");
   }
 
   ret = curl_mime_headers(p->part, list, 1);
 
   if(ret != CURLE_OK){
-    curl_slist_free_all(list);
+    if(list) curl_slist_free_all(list);
     return lcurl_fail_ex(L, p->err_mode, LCURL_ERROR_EASY, ret);
   }
 

--- a/src/lcmulti.c
+++ b/src/lcmulti.c
@@ -24,6 +24,7 @@
 #include "lcerror.h"
 #include "lcutils.h"
 #include "lchttppost.h"
+#include <stdio.h>
 
 #define LCURL_MULTI_NAME LCURL_PREFIX" Multi"
 static const char *LCURL_MULTI = LCURL_MULTI_NAME;
@@ -433,17 +434,21 @@ static int lcurl_opt_set_string_array_(lua_State *L, int opt){
     n = lua_rawlen(L, 2);
   }
 
+  fprintf(stderr, "\n>>> array size %d\n", n);
+
   if(n == 0){
     code = curl_multi_setopt(p->curl, opt, 0);
   }
   else{
     int i;
     char const* *val = malloc(sizeof(char*) * (n + 1));
+    fprintf(stderr, ">>> allocate size %d: %p\n", sizeof(char*) * (n + 1), val);
     if(!*val){
       return lcurl_fail_ex(L, p->err_mode, LCURL_ERROR_MULTI, CURLM_OUT_OF_MEMORY);
     }
     for(i = 1; i <= n; ++i){
       lua_rawgeti(L, 2, i);
+      fprintf(stderr, ">>> add string %s\n", lua_tostring(L, -1));
       val[i-1] = lua_tostring(L, -1);
       lua_pop(L, 1);
     }
@@ -451,6 +456,7 @@ static int lcurl_opt_set_string_array_(lua_State *L, int opt){
     code = curl_multi_setopt(p->curl, opt, val);
     free((void*)val);
   }
+  fprintf(stderr, ">>> setopt result %d\n", code);
 
   if(code != CURLM_OK){
     return lcurl_fail_ex(L, p->err_mode, LCURL_ERROR_MULTI, code);

--- a/src/lcmulti.c
+++ b/src/lcmulti.c
@@ -424,11 +424,17 @@ static int lcurl_opt_set_string_array_(lua_State *L, int opt){
   lcurl_multi_t *p = lcurl_getmulti(L);
   CURLMcode code;
   int n;
-  luaL_argcheck(L, lua_type(L, 2) == LUA_TTABLE, 2, "array expected");
-  n = lua_rawlen(L, 2);
+
+  if (lutil_is_null(L, 2)) {
+    n = 0;
+  }
+  else {
+    luaL_argcheck(L, lua_type(L, 2) == LUA_TTABLE, 2, "array expected");
+    n = lua_rawlen(L, 2);
+  }
+
   if(n == 0){
-    char *val[] = {NULL};
-    code = curl_multi_setopt(p->curl, opt, val);
+    code = curl_multi_setopt(p->curl, opt, 0);
   }
   else{
     int i;

--- a/src/lcmulti.c
+++ b/src/lcmulti.c
@@ -24,7 +24,6 @@
 #include "lcerror.h"
 #include "lcutils.h"
 #include "lchttppost.h"
-#include <stdio.h>
 
 #define LCURL_MULTI_NAME LCURL_PREFIX" Multi"
 static const char *LCURL_MULTI = LCURL_MULTI_NAME;
@@ -434,21 +433,17 @@ static int lcurl_opt_set_string_array_(lua_State *L, int opt){
     n = lua_rawlen(L, 2);
   }
 
-  fprintf(stderr, "\n>>> array size %d\n", n);
-
   if(n == 0){
     code = curl_multi_setopt(p->curl, opt, 0);
   }
   else{
     int i;
-    char const* *val = malloc(sizeof(char*) * (n + 1));
-    fprintf(stderr, ">>> allocate size %d: %p\n", sizeof(char*) * (n + 1), val);
-    if(!*val){
+    char const**val = malloc(sizeof(char*) * (n + 1));
+    if(!val){
       return lcurl_fail_ex(L, p->err_mode, LCURL_ERROR_MULTI, CURLM_OUT_OF_MEMORY);
     }
     for(i = 1; i <= n; ++i){
       lua_rawgeti(L, 2, i);
-      fprintf(stderr, ">>> add string %s\n", lua_tostring(L, -1));
       val[i-1] = lua_tostring(L, -1);
       lua_pop(L, 1);
     }
@@ -456,7 +451,6 @@ static int lcurl_opt_set_string_array_(lua_State *L, int opt){
     code = curl_multi_setopt(p->curl, opt, val);
     free((void*)val);
   }
-  fprintf(stderr, ">>> setopt result %d\n", code);
 
   if(code != CURLM_OK){
     return lcurl_fail_ex(L, p->err_mode, LCURL_ERROR_MULTI, code);

--- a/src/lcoptshare.h
+++ b/src/lcoptshare.h
@@ -14,11 +14,14 @@ OPT_ENTRY(unshare,              UNSHARE,                   LNG,     0 )
 FLG_ENTRY( LOCK_DATA_COOKIE                  )
 FLG_ENTRY( LOCK_DATA_DNS                     )
 FLG_ENTRY( LOCK_DATA_SSL_SESSION             )
+FLG_ENTRY( LOCK_DATA_CONNECT                 )
 
 #ifdef OPT_ENTRY_IS_NULL
 #  undef OPT_ENTRY
+#  undef OPT_ENTRY_IS_NULL
 #endif
 
 #ifdef FLG_ENTRY_IS_NULL
 #  undef FLG_ENTRY
+#  undef FLG_ENTRY_IS_NULL
 #endif

--- a/src/lcurl.c
+++ b/src/lcurl.c
@@ -270,6 +270,9 @@ static int luaopen_lcurl_(lua_State *L, const struct luaL_Reg *func){
 
   lcurl_util_set_const(L, lcurl_flags);
 
+  lutil_push_null(L);
+  lua_setfield(L, -2, "null");
+
   return 1;
 }
 

--- a/src/lcutils.c
+++ b/src/lcutils.c
@@ -171,8 +171,6 @@ int lcurl_set_callback(lua_State *L, lcurl_callback_t *c, int i, const char *met
   luaL_argcheck(L, !lua_isnoneornil(L, i), i, "no function present");
   luaL_argcheck(L, (top < (i + 2)), i + 2, "no arguments expected");
 
-  // if(top > (i + 1)) lua_settop(L, i + 1); // this for force ignore other arguments
-
   assert((top == i)||(top == (i + 1)));
 
   if(c->ud_ref != LUA_NOREF){
@@ -183,6 +181,19 @@ int lcurl_set_callback(lua_State *L, lcurl_callback_t *c, int i, const char *met
   if(c->cb_ref != LUA_NOREF){
     luaL_unref(L, LCURL_LUA_REGISTRY, c->cb_ref);
     c->cb_ref = LUA_NOREF;
+  }
+
+  if(lutil_is_null(L, i)){
+    if(top == (i + 1)){
+      // Do we can just ignore this?
+      luaL_argcheck(L, 
+        lua_isnoneornil(L, i + 1) || lutil_is_null(L, i + 1)
+        ,i + 1, "no context allowed when set callback to null"
+      );
+    }
+    lua_pop(L, top - i + 1);
+
+    return 1;
   }
 
   if(lua_gettop(L) == (i + 1)){// function + context

--- a/test/test_easy.lua
+++ b/test/test_easy.lua
@@ -153,9 +153,16 @@ function test_reset_write_callback()
   assert_equal(c, c:setopt_writefunction(f))
   assert_equal(c, c:setopt_writefunction(f.write, f))
   assert_equal(c, c:setopt_writefunction(print))
+  assert_equal(c, c:setopt_writefunction(print, null))
+  assert_equal(c, c:setopt_writefunction(null))
+  assert_equal(c, c:setopt_writefunction(null, nil))
+  assert_equal(c, c:setopt_writefunction(null, null))
   assert_error(function()c:setopt_writefunction()end)
   assert_error(function()c:setopt_writefunction(nil)end)
   assert_error(function()c:setopt_writefunction(nil, f)end)
+  assert_error(function()c:setopt_writefunction(null, {})end)
+  assert_error(function()c:setopt_writefunction(print, {}, nil)end)
+  assert_error(function()c:setopt_writefunction(print, {}, null)end)
 end
 
 function test_write_pass_01()
@@ -208,6 +215,38 @@ function test_write_coro()
   coroutine.resume(co2)
 
   assert_equal(co2, called)
+end
+
+function test_write_pass_null_context()
+  c = assert(curl.easy{
+    url = GET_URL;
+  })
+
+  local context
+  assert_equal(c, c:setopt_writefunction(function(ctx)
+    context = ctx
+    return true
+  end, null))
+
+  assert_equal(c, c:perform())
+  assert_equal(null, context)
+end
+
+function test_write_pass_nil_context()
+  c = assert(curl.easy{
+    url = GET_URL;
+  })
+
+  local context, called
+  assert_equal(c, c:setopt_writefunction(function(ctx)
+    context = ctx
+    called = true
+    return true
+  end, nil))
+
+  assert_equal(c, c:perform())
+  assert_true(called)
+  assert_nil(context)
 end
 
 end
@@ -381,9 +420,14 @@ function test_reset_header_callback()
   assert_equal(c, c:setopt_headerfunction(f))
   assert_equal(c, c:setopt_headerfunction(f.header, f))
   assert_equal(c, c:setopt_headerfunction(print))
+  assert_equal(c, c:setopt_headerfunction(null))
+  assert_equal(c, c:setopt_headerfunction(null, nil))
+  assert_equal(c, c:setopt_headerfunction(null, null))
   assert_error(function()c:setopt_headerfunction()end)
   assert_error(function()c:setopt_headerfunction(nil)end)
   assert_error(function()c:setopt_headerfunction(nil, f)end)
+  assert_error(function()c:setopt_headerfunction(null, {})end)
+  assert_error(function()c:setopt_headerfunction(print, {}, nil)end)
 end
 
 function test_header_pass_01()

--- a/test/test_easy.lua
+++ b/test/test_easy.lua
@@ -35,6 +35,8 @@ local POST_URL = "http://127.0.0.1:7090/post"
 local weak_ptr, gc_collect, is_curl_ge, read_file, stream, Stream, dump_request =
   utils.import('weak_ptr', 'gc_collect', 'is_curl_ge', 'read_file', 'stream', 'Stream', 'dump_request')
 
+local null = curl.null
+
 local ENABLE = true
 
 local _ENV = TEST_CASE'curl error'           if ENABLE then
@@ -1054,6 +1056,55 @@ function test_set_empty_array()
   c = curl.easy()
   c:setopt_httpheader({'X-Custom: value'})
   c:setopt_httpheader({})
+  local body, headers = assert_string(dump_request(c))
+  assert_not_match("X%-Custom:%s*value\r\n", headers)
+end
+
+end
+
+local _ENV = TEST_CASE'set_null'             if ENABLE then
+
+local c
+
+function teardown()
+  if c then c:close() end
+  c = nil
+end
+
+function test_string()
+  c = curl.easy()
+  c:setopt_accept_encoding('gzip')
+  local body, headers = assert_string(dump_request(c))
+  assert_match("Accept%-Encoding:%s*gzip", headers)
+
+  c:setopt_accept_encoding(null)
+  body, headers = assert_string(dump_request(c))
+  assert_not_match("Accept%-Encoding:%s*gzip", headers)
+end
+
+function test_string_via_table()
+  c = curl.easy()
+  c:setopt_accept_encoding('gzip')
+  local body, headers = assert_string(dump_request(c))
+  assert_match("Accept%-Encoding:%s*gzip", headers)
+
+  c:setopt{ accept_encoding = null }
+  body, headers = assert_string(dump_request(c))
+  assert_not_match("Accept%-Encoding:%s*gzip", headers)
+end
+
+function test_slist()
+  c = curl.easy()
+  c:setopt_httpheader({'X-Custom: value'})
+  c:setopt_httpheader(null)
+  local body, headers = assert_string(dump_request(c))
+  assert_not_match("X%-Custom:%s*value\r\n", headers)
+end
+
+function test_slist_via_table()
+  c = curl.easy()
+  c:setopt_httpheader({'X-Custom: value'})
+  c:setopt{httpheader = null}
   local body, headers = assert_string(dump_request(c))
   assert_not_match("X%-Custom:%s*value\r\n", headers)
 end

--- a/test/test_easy.lua
+++ b/test/test_easy.lua
@@ -1064,11 +1064,12 @@ end
 
 local _ENV = TEST_CASE'set_null'             if ENABLE then
 
-local c
+local c, m
 
 function teardown()
   if c then c:close() end
-  c = nil
+  if m then m:close() end
+  m, c = nil
 end
 
 function test_string()
@@ -1107,6 +1108,14 @@ function test_slist_via_table()
   c:setopt{httpheader = null}
   local body, headers = assert_string(dump_request(c))
   assert_not_match("X%-Custom:%s*value\r\n", headers)
+end
+
+function test_multi_set_array()
+  m = curl.multi()
+  m:setopt_pipelining_site_bl{
+    '127.0.0.1'
+  }
+  assert_equal(m, m:setopt_pipelining_site_bl(null))
 end
 
 end


### PR DESCRIPTION
This PR allows use
easy:setopt{
  httpheader = null,
  postdata = null,
}
So it possible reset easy with only one function.