### PR TITLE
Fix. Removed invalid semicolon

### DIFF
--- a/src/lceasy.h
+++ b/src/lceasy.h
@@ -47,7 +47,7 @@ struct lcurl_multi_tag;
 #define lcurl_multi_t struct lcurl_multi_tag
 #if LCURL_CURL_VER_GE(7,56,0)
 struct lcurl_mime_tag;
-#define lcurl_mime_t struct lcurl_mime_tag;
+#define lcurl_mime_t struct lcurl_mime_tag
 #endif
 #endif
 


### PR DESCRIPTION
Compiling the tag v0.3.8 I got some erros till I figured out that there is an invalid semicolon at the and of a define, it does not work.