### PR TITLE
Fix. Compile time warnings about unused var/typdefs

### DIFF
--- a/src/lceasy.c
+++ b/src/lceasy.c
@@ -124,7 +124,7 @@ static int lcurl_easy_cleanup(lua_State *L){
   int i;
 
   if(p->multi){
-    CURLMcode code = lcurl__multi_remove_handle(L, p->multi, p);
+    LCURL_UNUSED_VAR CURLMcode code = lcurl__multi_remove_handle(L, p->multi, p);
 
     //! @todo what I can do if I can not remove it???
   }

--- a/src/lcutils.h
+++ b/src/lcutils.h
@@ -25,11 +25,19 @@
 #  define LCURL_CC_SUPPORT_FORWARD_TYPEDEF 0
 #endif
 
+#ifdef __GNUC__
+  #define LCURL_UNUSED_TYPEDEF __attribute__ ((unused))
+#else
+  #define LCURL_UNUSED_TYPEDEF
+#endif
+
+#define LCURL_UNUSED_VAR LCURL_UNUSED_TYPEDEF
+
 #define LCURL_MAKE_VERSION(MIN, MAJ, PAT) ((MIN<<16) + (MAJ<<8) + PAT)
 #define LCURL_CURL_VER_GE(MIN, MAJ, PAT) (LIBCURL_VERSION_NUM >= LCURL_MAKE_VERSION(MIN, MAJ, PAT))
 
 #define LCURL_CONCAT_STATIC_ASSERT_IMPL_(x, y) LCURL_CONCAT1_STATIC_ASSERT_IMPL_ (x, y)
-#define LCURL_CONCAT1_STATIC_ASSERT_IMPL_(x, y) x##y
+#define LCURL_CONCAT1_STATIC_ASSERT_IMPL_(x, y) LCURL_UNUSED_TYPEDEF x##y
 #define LCURL_STATIC_ASSERT(expr) typedef char LCURL_CONCAT_STATIC_ASSERT_IMPL_(static_assert_failed_at_line_, __LINE__) [(expr) ? 1 : -1]
 
 #define LCURL_ASSERT_SAME_SIZE(a, b) LCURL_STATIC_ASSERT( sizeof(a) == sizeof(b) )


### PR DESCRIPTION
Close #113