### PR TITLE
add variant definition of lcurl_url_t

### DIFF
--- a/src/lcurlapi.h
+++ b/src/lcurlapi.h
@@ -19,11 +19,20 @@ void lcurl_url_initlib(lua_State *L, int nup);
 
 #if LCURL_CURL_VER_GE(7,62,0)
 
+#if LCURL_CC_SUPPORT_FORWARD_TYPEDEF
 typedef struct lcurl_url_tag {
   CURLU *url;
 
   int err_mode;
 }lcurl_url_t;
+#else
+struct lcurl_url_tag {
+  CURLU *url;
+
+  int err_mode;
+};
+#define lcurl_url_t struct lcurl_url_tag
+#endif
 
 int lcurl_url_create(lua_State *L, int error_mode);
 


### PR DESCRIPTION
like in lceasy.h

avoid this build error
```
In file included from src/lceasy.c:12:0:
src/lceasy.h:57:25: error: expected ';', identifier or '(' before 'struct'
     #define lcurl_url_t struct lcurl_url_tag
                         ^
src/lcurlapi.h:26:2: note: in expansion of macro 'lcurl_url_t'
 }lcurl_url_t;
  ^

Error: Build error: Failed compiling object src/lceasy.o
```