### PR TITLE
Fix. ZONEID support only since libcurl 7.65.0

### DIFF
--- a/src/lcopturl.h
+++ b/src/lcopturl.h
@@ -8,7 +8,10 @@ ENTRY_PART(query,         UPART_QUERY    , CURLUE_NO_QUERY        )
 ENTRY_PART(scheme,        UPART_SCHEME   , CURLUE_NO_SCHEME       )
 ENTRY_PART(url,           UPART_URL      , CURLUE_OK              )
 ENTRY_PART(user,          UPART_USER     , CURLUE_NO_USER         )
+
+#if LCURL_CURL_VER_GE(7,65,0)
 ENTRY_PART(zoneid,        UPART_ZONEID   , CURLUE_UNKNOWN_PART    )
+#endif
 
 ENTRY_FLAG(DEFAULT_PORT        )
 ENTRY_FLAG(NO_DEFAULT_PORT     )


### PR DESCRIPTION
Close #151 